### PR TITLE
feat(manifest): update branding and add new manifest file for Renomate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Cursor rules
+/.cursor/rules

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,0 +1,41 @@
+{
+  "name": "Renomate",
+  "short_name": "Renomate",
+  "description": "Your renovation mate",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#F9F9F9",
+  "theme_color": "#006600",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "renomate-logo.png",
+      "sizes": "333x333",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "favicon.png", 
+      "sizes": "333x333",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "pwa-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "pwa-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "categories": ["utilities", "productivity", "home"],
+  "screenshots": [],
+  "shortcuts": [],
+  "lang": "en",
+  "dir": "ltr"
+} 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,11 +11,11 @@ export default defineConfig({
 		SvelteKitPWA({
 			registerType: 'autoUpdate',
 			manifest: {
-				name: 'Oppuss',
-				short_name: 'Oppuss',
-				description: 'Room-by-Room Renovation Planner',
-				theme_color: '#D8CAB8',
-				background_color: '#FDFCF9',
+				name: 'Renomate',
+				short_name: 'Renomate',
+				description: 'Your renovation mate',
+				theme_color: '#006600',
+				background_color: '#F9F9F9',
 				icons: [
 					{
 						src: 'pwa-192x192.png',
@@ -32,6 +32,16 @@ export default defineConfig({
 						sizes: '512x512',
 						type: 'image/png',
 						purpose: 'maskable'
+					},
+					{
+						src: 'renomate-logo.png',
+						sizes: '333x333',
+						type: 'image/png'
+					},
+					{
+						src: 'favicon.png',
+						sizes: '333x333',
+						type: 'image/png'
 					}
 				],
 				display: 'standalone',


### PR DESCRIPTION
- Changed app name and description from "Oppuss" to "Renomate" in vite.config.ts and static manifest.json.
- Updated theme and background colors for a refreshed look.
- Added new icons for the application in the manifest.
- Included a new .gitignore entry for cursor rules.